### PR TITLE
Make the project compatible with the Arduino IDE

### DIFF
--- a/src/src.ino
+++ b/src/src.ino
@@ -1,0 +1,3 @@
+// This file intentionally left blank
+// It is used only to add support for the Arduino IDE
+// See other tabs for the code


### PR DESCRIPTION
The Arduino IDE requires that a sketch be located in a folder of the same name. When opening a file that does not meet this sketch/folder name matching requirement the Arduino IDE presents a dialog:

>The file "main.ino" needs to be inside a sketch folder named "main".
Create this folder, move the file, and continue?

After clicking "OK" the Arduino IDE currently moves only the file main.ino to the new folder, leaving behind the other source files. This causes compilation of the sketch to fail:
```
BlynkyLights-master\src\main\main.ino:63:100: fatal error: locationSpecific.h: No such file or directory

 #include "locationSpecific.h"   //Easily define different parameters for different microcontrollers
```
The solution I chose was to add a dummy .ino file that matches the folder name, as this was the least invasive change. The file was left empty other than an explanatory comment.